### PR TITLE
feat: ELK 스택 연동. 검색 성능 최적화. 리드미 추가.

### DIFF
--- a/ELK/logstash-post-service.conf
+++ b/ELK/logstash-post-service.conf
@@ -1,0 +1,39 @@
+input {
+  jdbc {
+    jdbc_validate_connection => true
+    jdbc_driver_library => "/usr/share/logstash/logstash-core/lib/jars/ojdbc11.jar"
+    jdbc_driver_class => "Java::oracle.jdbc.driver.OracleDriver"
+    jdbc_connection_string => "${DB_URL}"
+    jdbc_user => "${DB_USER}"
+    jdbc_password => "${DB_PASSWORD}"
+    jdbc_paging_enabled => true
+    jdbc_page_size => 50000
+    schedule => "*/5 * * * * *"
+    statement => "SELECT * FROM POST WHERE UPDATED_AT > :sql_last_value"
+    use_column_value => true
+    tracking_column => "updated_at"
+    tracking_column_type => "timestamp"
+    last_run_metadata_path => "/usr/share/logstash/.logstash_jdbc_last_run"
+    clean_run => true
+    record_last_run => true
+  }
+}
+filter {
+  mutate {
+    remove_field => ["@version", "@timestamp"]
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => ["http://elasticsearch:9200"]
+    index => "posts"
+    document_id => "%{post_id}"
+  }
+
+  stdout {
+    codec => rubydebug
+  }
+
+
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,72 @@
+
+
+# 🚀데일리 트래블: 일상을 여행으로 만드는 팀 프로젝트
+
+### 개요
+'데일리 트래블'은 사용자가 자유롭게 여행 장소와 일정을 공유할 수 있는 웹사이트입니다. 이 프로젝트는 팀 협업을 통해 개발되었으며, 여행을 좋아하는 사람들에게 유용한 정보를 제공하는 것을 목표로 합니다.
+![image](https://github.com/user-attachments/assets/50b6b241-e5e1-4f9f-97f9-3a56ab93caee)
+
+
+## Team 🏃‍♂️
+
+| <img src="https://avatars.githubusercontent.com/u/22585023?v=4" width="150" height="150"/> | <img src="https://avatars.githubusercontent.com/u/64997345?v=4" width="150" height="150"/> | <img src="https://avatars.githubusercontent.com/u/102151689?v=4" width="150" height="150"/> | <img src="https://avatars.githubusercontent.com/u/102151689?v=4" width="150" height="150"/> |
+| :----------------------------------------------------------------------------------------: | :----------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------: | :-----------------------------------------------------------------------------------------: |
+|                           [@recoild](https://github.com/recoild)                           |                       [@ChoiYoungHa](https://github.com/ChoiYoungHa)                       |                            [@0lYUMA](https://github.com/0lYUMA)                             |                            [@jjeong1015](https://github.com/jjeong1015)                      |
+
+### 역할 분담
+
+- **[0lYUMA](https://github.com/0lYUMA)**
+  - **팀장**
+  - 백엔드 개발
+  - 게시판 서비스 개발
+  - 게시판 성능 최적화
+  - 이미지 서버 연동
+
+- **[recoild](https://github.com/recoild)**
+  - 팀원
+  - 프론트엔드 및 백엔드 개발
+  - 유저 서비스 개발
+  - 게시판 성능 최적화
+
+- **[ChoiYoungHa](https://github.com/ChoiYoungHa)**
+  - 팀원
+  - 백엔드 개발
+  - 좋아요 서비스 개발
+  - 좋아요 성능 최적화
+
+- **[jjeong1015](https://github.com/jjeong1015)**
+  - 팀원
+  - 백엔드 개발
+  - 댓글 서비스 개발
+  - 댓글 성능 최적화
+
+
+## 주요 기능
+- 여행 게시글 작성 및 공유
+- 사용자 간 소통 기능 (댓글, 좋아요)
+- DB 스키마 유지 및 버전 관리를 위한 Flyway 도입
+- 구글 로그인 인증 후 인가를 담당하는 리소스 서버 기능
+- 트위터 스타일의 무한 스크롤링 게시글 목록 조회 기능
+
+## 사용 기술 스택
+- **프론트엔드**: TypeScript, Next.js, Tailwind CSS, ShadcnUI
+- **백엔드**: Spring Boot 3, JPA
+- **데이터베이스**: Oracle DB,  Redis DB
+- **검색 서비스**: ELK Stack (Elasticsearch, Logstash, Kibana)
+- **빌드 도구**: Gradle
+- **컨테이너화**: Docker Compose
+
+
+## 로컬 개발 환경
+![1](https://github.com/user-attachments/assets/cddfd0f4-1713-4ee6-8685-1df46b36bc5a)
+
+## 환경 설정
+팀원들은 사전에 공유한 env파일들을 백엔드, 프론트엔드 저장소 폴더에 붙여넣기 합니다.
+
+## 실행 순서
+1. 도커 컴포즈 실행
+```
+docker compose up -d
+```
+2. 스프링 부트 서버 실행
+3. (선택) 프론트엔드 실행

--- a/build.gradle
+++ b/build.gradle
@@ -22,8 +22,16 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+    //actuator
+    implementation 'org.springframework.boot:spring-boot-starter-actuator:3.3.2'
+
+
     //modelmapper
     implementation 'org.modelmapper:modelmapper:3.1.1'
+
+    //micrometer
+    implementation 'io.micrometer:micrometer-registry-prometheus:1.13.3'
+
 
     //spring-security-test
     testImplementation 'org.springframework.security:spring-security-test:6.3.1'

--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,10 @@ dependencies {
     //ojdbc11
     implementation 'com.oracle.database.jdbc:ojdbc11'
 
+    //elastic search 7.11.1
+    implementation 'org.springframework.data:spring-data-elasticsearch:4.2.12'
+
+
     //security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 

--- a/compose.yml
+++ b/compose.yml
@@ -2,9 +2,9 @@ services:
   oracledb:
     image: gvenzl/oracle-free:23-slim-faststart
     environment:
-      ORACLE_PASSWORD: test
-      APP_USER: test
-      APP_USER_PASSWORD: test
+      ORACLE_RANDOM_PASSWORD: true
+      APP_USER: ${DB_USER}
+      APP_USER_PASSWORD: ${DB_PASSWORD}
     healthcheck:
       test: [ "CMD", "healthcheck.sh" ]
       interval: 1s
@@ -39,6 +39,43 @@ services:
     volumes:
       - grafana-data:/var/lib/grafana
 
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.11.1
+    environment:
+      - discovery.type=single-node
+      - xpack.security.enabled=false
+      - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+    ports:
+      - "9200:9200"
+    volumes:
+      - es-data:/usr/share/elasticsearch/data
+
+  logstash:
+    image: docker.elastic.co/logstash/logstash:7.11.1
+    environment:
+      - DB_USER=${DB_USER}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - DB_URL=${DB_URL_LOGSTASH}
+    volumes:
+      - ./ELK/logstash-post-service.conf:/usr/share/logstash/pipeline/logstash-post-service.conf
+      - ./ELK/ojdbc11.jar:/usr/share/logstash/logstash-core/lib/jars/ojdbc11.jar
+    ports:
+      - "5044:5044"
+    depends_on:
+      - elasticsearch
+      - oracledb
+
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.11.1
+    environment:
+      - ELASTICSEARCH_HOSTS=http://elasticsearch:9200
+    ports:
+      - "5601:5601"
+    depends_on:
+      - elasticsearch
+
 volumes:
   oracle-data:
   grafana-data:
+  es-data:

--- a/compose.yml
+++ b/compose.yml
@@ -1,27 +1,44 @@
 services:
   oracledb:
-    image: gvenzl/oracle-free:23
+    image: gvenzl/oracle-free:23-slim-faststart
     environment:
       ORACLE_PASSWORD: test
       APP_USER: test
       APP_USER_PASSWORD: test
     healthcheck:
       test: [ "CMD", "healthcheck.sh" ]
-      interval: 10s
+      interval: 1s
       timeout: 5s
       retries: 10
-      start_period: 5s
+      start_period: 1s
     ports:
       - "1521:1521"
     volumes:
       - oracle-data:/opt/oracle/oradata
-    restart: always
 
   redis:
     image: redis:latest
     ports:
       - "6379:6379"
-    restart: always
+
+  prometheus:
+    image: prom/prometheus:latest
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+    command:
+      - '--config.file=/etc/prometheus/prometheus.yml'
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:latest
+    ports:
+      - "9091:3000"
+    environment:
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    volumes:
+      - grafana-data:/var/lib/grafana
 
 volumes:
   oracle-data:
+  grafana-data:

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 2s
+
+scrape_configs:
+  - job_name: 'spring-boot-app'
+    static_configs:
+      - targets: [ 'host.docker.internal:8080' ]
+    metrics_path: '/actuator/prometheus'

--- a/src/main/java/com/fisa/dailytravel/global/config/ElasticSearchConfig.java
+++ b/src/main/java/com/fisa/dailytravel/global/config/ElasticSearchConfig.java
@@ -1,0 +1,19 @@
+package com.fisa.dailytravel.global.config;
+
+import org.elasticsearch.client.RestHighLevelClient;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.RestClients;
+import org.springframework.data.elasticsearch.config.AbstractElasticsearchConfiguration;
+
+@Configuration
+public class ElasticSearchConfig extends AbstractElasticsearchConfiguration {
+
+    @Override
+    public RestHighLevelClient elasticsearchClient() {
+        ClientConfiguration clientConfiguration = ClientConfiguration.builder()
+                .connectedTo("localhost:9200")
+                .build();
+        return RestClients.create(clientConfiguration).rest();
+    }
+}

--- a/src/main/java/com/fisa/dailytravel/global/config/SecurityConfig.java
+++ b/src/main/java/com/fisa/dailytravel/global/config/SecurityConfig.java
@@ -19,7 +19,8 @@ public class SecurityConfig {
             "/public/**",
             "/swagger-ui/**",
             "/v3/api-docs/**",
-            "/swagger-resources/**"
+            "/swagger-resources/**",
+            "/actuator/**",
     };
 
     @Bean

--- a/src/main/java/com/fisa/dailytravel/post/controller/PostController.java
+++ b/src/main/java/com/fisa/dailytravel/post/controller/PostController.java
@@ -1,10 +1,7 @@
 package com.fisa.dailytravel.post.controller;
 
 import com.fisa.dailytravel.global.dto.ApiResponse;
-import com.fisa.dailytravel.post.dto.PostPagingRequest;
-import com.fisa.dailytravel.post.dto.PostPagingResponse;
-import com.fisa.dailytravel.post.dto.PostRequest;
-import com.fisa.dailytravel.post.dto.PostResponse;
+import com.fisa.dailytravel.post.dto.*;
 import com.fisa.dailytravel.post.fasade.RedissonLockPostFacade;
 import com.fisa.dailytravel.post.service.PostServiceImpl;
 import lombok.RequiredArgsConstructor;
@@ -35,6 +32,18 @@ public class PostController {
     public ApiResponse<PostPagingResponse> getPosts(@ModelAttribute PostPagingRequest postPagingRequest, JwtAuthenticationToken principal) {
         String uuid = principal.getName();
         return ApiResponse.ok(postService.getAllPosts(uuid, postPagingRequest));
+    }
+
+    @GetMapping("/v1/post/search")
+    public ApiResponse<PostPagingResponse> searchPostsV1(@ModelAttribute PostSearchPagingRequest postSearchPagingRequest, JwtAuthenticationToken principal) throws Exception {
+        String uuid = principal.getName();
+        return ApiResponse.ok(postService.searchPosts(uuid, postSearchPagingRequest));
+    }
+
+    @GetMapping("/v2/post/search")
+    public ApiResponse<PostPagingResponse> searchPostsV2(@ModelAttribute PostSearchPagingRequest postSearchPagingRequest, JwtAuthenticationToken principal) throws Exception {
+        String uuid = principal.getName();
+        return ApiResponse.ok(postService.searchPostsWithES(uuid, postSearchPagingRequest));
     }
 
     @PutMapping("/v1/post")

--- a/src/main/java/com/fisa/dailytravel/post/dto/PostPreviewResponse.java
+++ b/src/main/java/com/fisa/dailytravel/post/dto/PostPreviewResponse.java
@@ -19,6 +19,7 @@ public class PostPreviewResponse {
     private String title;
     private String author;
     private String authorProfile;
+    private String content;
     private int likeCount;
     private List<String> imageFiles;
     private List<String> hashtags;
@@ -34,6 +35,7 @@ public class PostPreviewResponse {
                 .likeCount(post.getLikesCount())
                 .imageFiles(imageFiles)
                 .hashtags(hashtags)
+                .content(post.getContent())
                 .creationDate(post.getCreatedAt())
                 .build();
     }

--- a/src/main/java/com/fisa/dailytravel/post/dto/PostSearchPagingRequest.java
+++ b/src/main/java/com/fisa/dailytravel/post/dto/PostSearchPagingRequest.java
@@ -1,0 +1,16 @@
+package com.fisa.dailytravel.post.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PostSearchPagingRequest {
+    private String search;
+    private int page;
+    private int count;
+}

--- a/src/main/java/com/fisa/dailytravel/post/models/PostDoc.java
+++ b/src/main/java/com/fisa/dailytravel/post/models/PostDoc.java
@@ -1,0 +1,55 @@
+package com.fisa.dailytravel.post.models;
+
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+import java.time.LocalDateTime;
+
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Document(indexName = "posts")
+public class PostDoc {
+    @Id
+    @Field(name = "post_id", type = FieldType.Keyword)
+    private Long id;
+
+    @Field(name = "users_id", type = FieldType.Keyword)
+    private String userId;
+
+    @Field(name = "latitude", type = FieldType.Double)
+    private Double latitude;
+
+    @Field(name = "thumbnail", type = FieldType.Text)
+    private String thumbnail;
+
+    @Field(name = "likes_count", type = FieldType.Integer)
+    private int likesCount;
+
+    @Field(name = "created_at", type = FieldType.Date, format = {}, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    private LocalDateTime createdAt;
+
+    @Field(name = "updated_at", type = FieldType.Date, format = {}, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
+    private LocalDateTime updatedAt;
+
+    @Field(name = "post_content", type = FieldType.Text)
+    private String postContent;
+
+    @Field(name = "longitude", type = FieldType.Double)
+    private Double longitude;
+
+    @Field(name = "post_title", type = FieldType.Text)
+    private String title;
+
+    @Field(name = "place_name", type = FieldType.Text)
+    private String placeName;
+
+}

--- a/src/main/java/com/fisa/dailytravel/post/repository/PostDocRepository.java
+++ b/src/main/java/com/fisa/dailytravel/post/repository/PostDocRepository.java
@@ -1,0 +1,11 @@
+package com.fisa.dailytravel.post.repository;
+
+import com.fisa.dailytravel.post.models.PostDoc;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+import java.util.List;
+
+public interface PostDocRepository extends ElasticsearchRepository<PostDoc, String> {
+    List<PostDoc> findByPostContentContaining(String postContent, Pageable pageable);
+}

--- a/src/main/java/com/fisa/dailytravel/post/repository/PostRepository.java
+++ b/src/main/java/com/fisa/dailytravel/post/repository/PostRepository.java
@@ -14,7 +14,7 @@ import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
-    @EntityGraph(attributePaths = {"postHashtags", "images"})
+    //    @EntityGraph(attributePaths = {"postHashtags", "images"})
     Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
     @Query("SELECT p FROM Post p ORDER BY p.createdAt DESC")
@@ -25,6 +25,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     @Query("SELECT p FROM Post p WHERE p.user.id = :userId ORDER BY p.createdAt DESC ")
     List<Post> findLatestPostByUserId(@Param("userId") Long userId, Pageable pageable);
+
+    List<Post> findByContentContaining(String content, Pageable pageable);
 
     int countByTitle(String title);
 }

--- a/src/main/java/com/fisa/dailytravel/post/service/PostService.java
+++ b/src/main/java/com/fisa/dailytravel/post/service/PostService.java
@@ -1,9 +1,6 @@
 package com.fisa.dailytravel.post.service;
 
-import com.fisa.dailytravel.post.dto.PostPagingRequest;
-import com.fisa.dailytravel.post.dto.PostPagingResponse;
-import com.fisa.dailytravel.post.dto.PostRequest;
-import com.fisa.dailytravel.post.dto.PostResponse;
+import com.fisa.dailytravel.post.dto.*;
 
 import java.io.IOException;
 
@@ -17,4 +14,8 @@ public interface PostService {
     String modifyPost(String uuid, PostRequest postRequest) throws IOException;
 
     String deletePost(String uuid, Long postId);
+
+    PostPagingResponse searchPosts(String uuid, PostSearchPagingRequest postSearchPagingRequest) throws Exception;
+
+    PostPagingResponse searchPostsWithES(String uuid, PostSearchPagingRequest search) throws Exception;
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,6 +19,12 @@ spring:
     validateOnMigrate: true # 마이그레이션 실행 전에 스키마가 예상대로 되어 있는지 검증합니다.
     locations: classpath:db/migration # 마이그레이션 파일의 위치를 지정합니다.
 
+  data:
+    elasticsearch:
+      repositories:
+        enabled: true
+      url: localhost:9200
+
   datasource:
     url: ${DB_URL}
     username: ${DB_USER}
@@ -87,3 +93,12 @@ cloud:
     credentials:
       accessKey: ${S3_ACCESS_KEY}
       secretKey: ${S3_SECRET_KEY}
+
+logging:
+  level:
+    org:
+      springframework:
+        data:
+          elasticsearch:
+            client:
+              WIRE: TRACE

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -47,6 +47,21 @@ server:
       enabled: false # disable default whitelabel error page.
   shutdown: graceful
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: "*"
+  metrics:
+    tags:
+      application: ${spring.application.name}
+    export:
+      prometheus:
+        enabled: true
+  endpoint:
+    prometheus:
+      enabled: true
+    show-details: always
 
 keycloak:
   auth-server-url: ${KEYCLOAK_SERVER_URL}

--- a/src/test/java/com/fisa/dailytravel/post/PostServiceTest.java
+++ b/src/test/java/com/fisa/dailytravel/post/PostServiceTest.java
@@ -2,7 +2,9 @@ package com.fisa.dailytravel.post;
 
 import com.fisa.dailytravel.post.dto.PostRequest;
 import com.fisa.dailytravel.post.fasade.RedissonLockPostFacade;
+import com.fisa.dailytravel.post.models.Post;
 import com.fisa.dailytravel.post.repository.PostRepository;
+import com.fisa.dailytravel.user.repository.UserRepository;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -10,6 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
@@ -22,6 +25,7 @@ import java.util.concurrent.Executors;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+
 @SpringBootTest
 public class PostServiceTest {
 
@@ -30,6 +34,34 @@ public class PostServiceTest {
 
     @Autowired
     private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    @Transactional
+    public void insertMillionPosts() {
+        for (int i = 1; i <= 1000000; i++) {
+            Post post = Post.builder()
+                    .title("Title " + i)
+                    .content("Content " + i)
+                    .placeName("Place " + i)
+                    .likesCount(0)
+                    .thumbnail("thumbnail" + i + ".jpg")
+                    .latitude(Math.random() * 180 - 90)  // 예시 좌표
+                    .longitude(Math.random() * 360 - 180)  // 예시 좌표
+                    .user(userRepository.findByUuid("115521364043265380969"))  // 예시 사용자
+                    .build();
+            postRepository.save(post);
+
+            // 일정 수의 데이터를 배치로 저장하고 플러시/클리어
+            if (i % 1000 == 0) {
+                postRepository.flush();
+//                postRepository.clear();
+            }
+        }
+    }
+
 
     private PostRequest createRequestPost() {
         MockMultipartFile imageFile2 = new MockMultipartFile("imageFile2", "image2.jpg", "image/jpeg", "image content 2".getBytes());


### PR DESCRIPTION
1. 프로메테우스, 그라파나 연동하여 성능 측정
![image](https://github.com/user-attachments/assets/f312e54d-f535-4d97-b0a1-e6d4dfe02e83)
도입 이유: ELK스택은 검색 서비스로 활용하고 로깅, 성능 측정은 특화된 오픈 소스에 맡기는 것을 생각하였습니다. 

2. ELK 스택 연동
![image](https://github.com/user-attachments/assets/0a7d71ee-8c0d-4a46-9066-600e57205985)
compose.yml을 수정하여 ELK스택을 연동하였습니다. 위의 사진처럼 설정한 컨테이너 목록이 많아 메모리에 위험이 있으면 연락 부탁드립니다.

3. 검색 성능 최적화
![image](https://github.com/user-attachments/assets/a3d9f9e2-7afb-488f-a654-bb5e602842a9)
