### PR TITLE
refactor: 게시글 수정, 생성 리팩토링. flyway 설정 수정. jpa batch 설정 수정.

### DIFF
--- a/src/main/java/com/fisa/dailytravel/global/config/S3Uploader.java
+++ b/src/main/java/com/fisa/dailytravel/global/config/S3Uploader.java
@@ -3,14 +3,20 @@ package com.fisa.dailytravel.global.config;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.amazonaws.util.IOUtils;
+import com.fisa.dailytravel.global.dto.ByteResource;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.net.URL;
 
 @RequiredArgsConstructor
 @Component
@@ -39,6 +45,21 @@ public class S3Uploader {
         amazonS3.putObject(putObjectRequest);
 
         return amazonS3.getUrl(bucket, s3FileName).toString();
+    }
+
+    //이미지 다운로드
+    public ByteResource downloadImage(String s3url) throws IOException {
+        URL url = new URL(s3url);
+        String key = url.getPath();
+
+        String fileName = key.substring(key.lastIndexOf(bucket) + bucket.length() + 1);
+
+        S3Object o = amazonS3.getObject(new GetObjectRequest(bucket, fileName));
+
+        S3ObjectInputStream objectInputStream = o.getObjectContent();
+        byte[] bytes = IOUtils.toByteArray(objectInputStream);
+        String contentType = o.getObjectMetadata().getContentType();
+        return new ByteResource(bytes, contentType);
     }
 
     // 이미지 삭제

--- a/src/main/java/com/fisa/dailytravel/global/dto/ByteResource.java
+++ b/src/main/java/com/fisa/dailytravel/global/dto/ByteResource.java
@@ -1,0 +1,13 @@
+package com.fisa.dailytravel.global.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ByteResource {
+    private byte[] resource;
+    private String contentType;
+}

--- a/src/main/java/com/fisa/dailytravel/post/controller/PostController.java
+++ b/src/main/java/com/fisa/dailytravel/post/controller/PostController.java
@@ -1,20 +1,39 @@
 package com.fisa.dailytravel.post.controller;
 
+import com.fisa.dailytravel.global.config.S3Uploader;
 import com.fisa.dailytravel.global.dto.ApiResponse;
-import com.fisa.dailytravel.post.dto.*;
+import com.fisa.dailytravel.global.dto.ByteResource;
+import com.fisa.dailytravel.post.dto.PostPagingRequest;
+import com.fisa.dailytravel.post.dto.PostPagingResponse;
+import com.fisa.dailytravel.post.dto.PostRequest;
+import com.fisa.dailytravel.post.dto.PostResponse;
+import com.fisa.dailytravel.post.dto.PostSearchPagingRequest;
 import com.fisa.dailytravel.post.fasade.RedissonLockPostFacade;
 import com.fisa.dailytravel.post.service.PostServiceImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 @RequiredArgsConstructor
 @RestController
 public class PostController {
     private final PostServiceImpl postService;
     private final RedissonLockPostFacade redissonLockPostFacade;
+    private final S3Uploader s3Uploader;
 
     @PostMapping("/v1/post")
     public ApiResponse<String> createPost(@ModelAttribute PostRequest postRequest, JwtAuthenticationToken principal) throws IOException {
@@ -26,6 +45,21 @@ public class PostController {
     public ApiResponse<PostResponse> getPost(@PathVariable("id") String postId, JwtAuthenticationToken principal) {
         String uuid = principal.getName();
         return ApiResponse.ok(postService.getPost(uuid, Long.valueOf(postId)));
+    }
+
+    @GetMapping("/v1/post/image")
+    public ResponseEntity<byte[]> getImage(@RequestParam("s3url") String s3url, JwtAuthenticationToken principal) throws IOException {
+        String uuid = principal.getName();
+        ByteResource byteResource = s3Uploader.downloadImage(s3url);
+
+
+        String fileName = s3url.substring(s3url.lastIndexOf("/") + 1);
+        fileName = URLEncoder.encode(fileName, StandardCharsets.UTF_8);
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType(byteResource.getContentType()))
+                .header("Content-Disposition", "attachment; filename=\"" + fileName + "\"")
+                .body(byteResource.getResource());
     }
 
     @GetMapping("/v1/post")

--- a/src/main/java/com/fisa/dailytravel/post/dto/PostImageResponse.java
+++ b/src/main/java/com/fisa/dailytravel/post/dto/PostImageResponse.java
@@ -1,0 +1,4 @@
+package com.fisa.dailytravel.post.dto;
+
+public class PostImageResponse {
+}

--- a/src/main/java/com/fisa/dailytravel/post/dto/PostResponse.java
+++ b/src/main/java/com/fisa/dailytravel/post/dto/PostResponse.java
@@ -3,7 +3,11 @@ package com.fisa.dailytravel.post.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fisa.dailytravel.comment.dto.CommentResponse;
 import com.fisa.dailytravel.post.models.Post;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -29,8 +33,9 @@ public class PostResponse {
     private LocalDateTime creationDate;
     private List<String> hashtags;
     private List<CommentResponse> comments;
+    private boolean mine;
 
-    public static PostResponse of(Post post, List<String> imageFiles, List<String> hashtags, String authorProfileImagePath, List<CommentResponse> comments) {
+    public static PostResponse of(Post post, List<String> imageFiles, List<String> hashtags, String authorProfileImagePath, List<CommentResponse> comments, boolean mine) {
         return PostResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())
@@ -46,6 +51,7 @@ public class PostResponse {
                 .hashtags(hashtags)
                 .creationDate(post.getCreatedAt())
                 .comments(comments)
+                .mine(mine)
                 .build();
     }
 }

--- a/src/main/java/com/fisa/dailytravel/post/models/Hashtag.java
+++ b/src/main/java/com/fisa/dailytravel/post/models/Hashtag.java
@@ -1,7 +1,19 @@
 package com.fisa.dailytravel.post.models;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -11,7 +23,6 @@ import java.util.Set;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@EqualsAndHashCode(of = "id")
 @Table(name = "hashtag")
 @Entity
 public class Hashtag {

--- a/src/main/java/com/fisa/dailytravel/post/models/Hashtag.java
+++ b/src/main/java/com/fisa/dailytravel/post/models/Hashtag.java
@@ -11,6 +11,7 @@ import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -23,12 +24,13 @@ import java.util.Set;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EqualsAndHashCode(of = "id")
 @Table(name = "hashtag")
 @Entity
 public class Hashtag {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "hashtag_seq")
-    @SequenceGenerator(name = "hashtag_seq", sequenceName = "hashtag_seq", allocationSize = 1)
+    @SequenceGenerator(name = "hashtag_seq", sequenceName = "hashtag_seq", allocationSize = 10)
     @Column(name = "hashtag_id")
     private Long id;
 

--- a/src/main/java/com/fisa/dailytravel/post/models/Image.java
+++ b/src/main/java/com/fisa/dailytravel/post/models/Image.java
@@ -1,7 +1,20 @@
 package com.fisa.dailytravel.post.models;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -14,7 +27,7 @@ import lombok.*;
 public class Image {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "image_seq")
-    @SequenceGenerator(name = "image_seq", sequenceName = "image_seq", allocationSize = 1)
+    @SequenceGenerator(name = "image_seq", sequenceName = "image_seq", allocationSize = 10)
     @Column(name = "image_id")
     private Long id;
 

--- a/src/main/java/com/fisa/dailytravel/post/models/Post.java
+++ b/src/main/java/com/fisa/dailytravel/post/models/Post.java
@@ -4,8 +4,22 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fisa.dailytravel.comment.models.Comment;
 import com.fisa.dailytravel.like.models.Like;
 import com.fisa.dailytravel.user.models.User;
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -18,7 +32,6 @@ import java.util.Set;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@EqualsAndHashCode(of = "id")
 @Table(name = "post")
 @Entity
 public class Post {

--- a/src/main/java/com/fisa/dailytravel/post/models/Post.java
+++ b/src/main/java/com/fisa/dailytravel/post/models/Post.java
@@ -17,6 +17,7 @@ import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -32,6 +33,7 @@ import java.util.Set;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@EqualsAndHashCode(of = "id")
 @Table(name = "post")
 @Entity
 public class Post {

--- a/src/main/java/com/fisa/dailytravel/post/models/PostDoc.java
+++ b/src/main/java/com/fisa/dailytravel/post/models/PostDoc.java
@@ -40,7 +40,7 @@ public class PostDoc {
     @Field(name = "updated_at", type = FieldType.Date, format = {}, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'")
     private LocalDateTime updatedAt;
 
-    @Field(name = "post_content", type = FieldType.Text)
+    @Field(name = "post_content", type = FieldType.Keyword)
     private String postContent;
 
     @Field(name = "longitude", type = FieldType.Double)

--- a/src/main/java/com/fisa/dailytravel/post/models/PostHashtag.java
+++ b/src/main/java/com/fisa/dailytravel/post/models/PostHashtag.java
@@ -1,14 +1,27 @@
 package com.fisa.dailytravel.post.models;
 
-import jakarta.persistence.*;
-import lombok.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.SequenceGenerator;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@EqualsAndHashCode(of = "id")
+@EqualsAndHashCode(of = {"post", "hashtag"})
 @Table(name = "post_hashtag")
 @Entity
 public class PostHashtag {

--- a/src/main/java/com/fisa/dailytravel/post/models/PostHashtag.java
+++ b/src/main/java/com/fisa/dailytravel/post/models/PostHashtag.java
@@ -27,7 +27,7 @@ import lombok.Setter;
 public class PostHashtag {
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "post_hashtag_seq")
-    @SequenceGenerator(name = "post_hashtag_seq", sequenceName = "post_hashtag_seq", allocationSize = 1)
+    @SequenceGenerator(name = "post_hashtag_seq", sequenceName = "post_hashtag_seq", allocationSize = 10)
     @Column(name = "post_hashtag_id")
     private Long id;
 

--- a/src/main/java/com/fisa/dailytravel/post/repository/HashTagRepository.java
+++ b/src/main/java/com/fisa/dailytravel/post/repository/HashTagRepository.java
@@ -4,7 +4,10 @@ import com.fisa.dailytravel.post.models.Hashtag;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface HashTagRepository extends JpaRepository<Hashtag, Long> {
 
+    Optional<Hashtag> findByHashtagName(String hashtag);
 }

--- a/src/main/java/com/fisa/dailytravel/post/repository/ImageRepository.java
+++ b/src/main/java/com/fisa/dailytravel/post/repository/ImageRepository.java
@@ -3,6 +3,9 @@ package com.fisa.dailytravel.post.repository;
 import com.fisa.dailytravel.post.models.Image;
 import com.fisa.dailytravel.post.models.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,4 +15,9 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
     List<Image> findByPostId(Long postId);
 
     void deleteAllByPost(Post post);
+    
+    @Modifying
+    @Query("DELETE FROM Image i WHERE i.post.id = :postId")
+    void deleteByPostId(@Param("postId") Long postId);
+
 }

--- a/src/main/java/com/fisa/dailytravel/post/repository/PostDocRepository.java
+++ b/src/main/java/com/fisa/dailytravel/post/repository/PostDocRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchRepository
 import java.util.List;
 
 public interface PostDocRepository extends ElasticsearchRepository<PostDoc, String> {
-    List<PostDoc> findByPostContentContaining(String postContent, Pageable pageable);
+    List<PostDoc> findByPostContentContainingOrderByCreatedAt(String postContent, Pageable pageable);
 }

--- a/src/main/java/com/fisa/dailytravel/post/repository/PostHashtagRepository.java
+++ b/src/main/java/com/fisa/dailytravel/post/repository/PostHashtagRepository.java
@@ -3,7 +3,11 @@ package com.fisa.dailytravel.post.repository;
 import com.fisa.dailytravel.post.models.Post;
 import com.fisa.dailytravel.post.models.PostHashtag;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -12,4 +16,9 @@ public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> 
     List<PostHashtag> findByPostId(Long postId);
 
     void deleteByPost(Post post);
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM PostHashtag ph WHERE ph.post.id = :postId")
+    void deleteByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/fisa/dailytravel/post/repository/PostHashtagRepository.java
+++ b/src/main/java/com/fisa/dailytravel/post/repository/PostHashtagRepository.java
@@ -11,5 +11,5 @@ import java.util.List;
 public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> {
     List<PostHashtag> findByPostId(Long postId);
 
-    void deleteAllByPost(Post post);
+    void deleteByPost(Post post);
 }

--- a/src/main/java/com/fisa/dailytravel/post/repository/PostHashtagRepository.java
+++ b/src/main/java/com/fisa/dailytravel/post/repository/PostHashtagRepository.java
@@ -7,7 +7,6 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -18,7 +17,6 @@ public interface PostHashtagRepository extends JpaRepository<PostHashtag, Long> 
     void deleteByPost(Post post);
 
     @Modifying
-    @Transactional
     @Query("DELETE FROM PostHashtag ph WHERE ph.post.id = :postId")
     void deleteByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/com/fisa/dailytravel/post/repository/PostRepository.java
+++ b/src/main/java/com/fisa/dailytravel/post/repository/PostRepository.java
@@ -25,6 +25,9 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     @EntityGraph(attributePaths = {"postHashtags.hashtag", "comments.user", "user", "comments"})
     Optional<Post> findById(Long id);
 
+    @EntityGraph(attributePaths = {"postHashtags.hashtag", "user"})
+    Optional<Post> findPostAndPostHashtagsById(Long id);
+
     @Query("SELECT p FROM Post p WHERE p.user.id = :userId ORDER BY p.createdAt DESC ")
     List<Post> findLatestPostByUserId(@Param("userId") Long userId, Pageable pageable);
 

--- a/src/main/java/com/fisa/dailytravel/post/repository/PostRepository.java
+++ b/src/main/java/com/fisa/dailytravel/post/repository/PostRepository.java
@@ -14,7 +14,9 @@ import java.util.Optional;
 
 @Repository
 public interface PostRepository extends JpaRepository<Post, Long> {
-    //    @EntityGraph(attributePaths = {"postHashtags", "images"})
+    List<Post> findAllByIdIn(List<Long> postIds);
+
+    //    @EntityGraph(attributePaths = {"postHashtags.hashtag", "images"})
     Page<Post> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
     @Query("SELECT p FROM Post p ORDER BY p.createdAt DESC")

--- a/src/main/java/com/fisa/dailytravel/post/service/PostServiceImpl.java
+++ b/src/main/java/com/fisa/dailytravel/post/service/PostServiceImpl.java
@@ -3,9 +3,22 @@ package com.fisa.dailytravel.post.service;
 import com.fisa.dailytravel.comment.dto.CommentResponse;
 import com.fisa.dailytravel.comment.models.Comment;
 import com.fisa.dailytravel.global.config.S3Uploader;
-import com.fisa.dailytravel.post.dto.*;
-import com.fisa.dailytravel.post.models.*;
-import com.fisa.dailytravel.post.repository.*;
+import com.fisa.dailytravel.post.dto.PostPagingRequest;
+import com.fisa.dailytravel.post.dto.PostPagingResponse;
+import com.fisa.dailytravel.post.dto.PostPreviewResponse;
+import com.fisa.dailytravel.post.dto.PostRequest;
+import com.fisa.dailytravel.post.dto.PostResponse;
+import com.fisa.dailytravel.post.dto.PostSearchPagingRequest;
+import com.fisa.dailytravel.post.models.Hashtag;
+import com.fisa.dailytravel.post.models.Image;
+import com.fisa.dailytravel.post.models.Post;
+import com.fisa.dailytravel.post.models.PostDoc;
+import com.fisa.dailytravel.post.models.PostHashtag;
+import com.fisa.dailytravel.post.repository.HashTagRepository;
+import com.fisa.dailytravel.post.repository.ImageRepository;
+import com.fisa.dailytravel.post.repository.PostDocRepository;
+import com.fisa.dailytravel.post.repository.PostHashtagRepository;
+import com.fisa.dailytravel.post.repository.PostRepository;
 import com.fisa.dailytravel.user.models.User;
 import com.fisa.dailytravel.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -78,6 +91,7 @@ public class PostServiceImpl implements PostService {
         List<CommentResponse> comments = new ArrayList<>();
         String authorProfileImagePath = "";
 
+        boolean mine = false;
         if (post.isPresent()) {
             List<PostHashtag> postHashtags = postHashtagRepository.findByPostId(postId);
             for (PostHashtag postHashtag : postHashtags) {
@@ -94,13 +108,17 @@ public class PostServiceImpl implements PostService {
             for (Comment comment : commentList) {
                 comments.add(CommentResponse.of(comment));
             }
+
+            if (post.get().getUser().getUuid().equals(uuid)) {
+                mine = true;
+            }
         }
 
         getPostImages(images);
 
         imageFiles = getPostImages(images);
 
-        return PostResponse.of(post.get(), imageFiles, hashtags, authorProfileImagePath, comments);
+        return PostResponse.of(post.get(), imageFiles, hashtags, authorProfileImagePath, comments, mine);
     }
 
     public void savePostImages(Post post, List<MultipartFile> imageFiles) throws IOException {

--- a/src/main/java/com/fisa/dailytravel/post/service/PostServiceImpl.java
+++ b/src/main/java/com/fisa/dailytravel/post/service/PostServiceImpl.java
@@ -87,6 +87,17 @@ public class PostServiceImpl implements PostService {
 
                 post.getPostHashtags().add(postHashtag);
                 postHashtagRepository.save(postHashtag);
+//                post.getPostHashtags().stream().filter(
+//                        postHashtag1 ->
+//                                postHashtag1.getHashtag().getHashtagName().equals(hashtag.getHashtagName())
+//                ).findFirst().ifPresentOrElse(
+//                        postHashtag1 -> {
+//                        },
+//                        () -> {
+//                            post.getPostHashtags().add(postHashtag);
+//                            postHashtagRepository.save(postHashtag);
+//                        }
+//                );
             }
         }
 

--- a/src/main/java/com/fisa/dailytravel/post/service/PostServiceImpl.java
+++ b/src/main/java/com/fisa/dailytravel/post/service/PostServiceImpl.java
@@ -193,7 +193,7 @@ public class PostServiceImpl implements PostService {
             }
 
             List<Image> images = imageRepository.findByPostId(post.getId());
-            images.add(Image.builder().imagePath(post.getThumbnail()).build());
+//            images.add(Image.builder().imagePath(post.getThumbnail()).build());
 
             postPreviewResponses.add(PostPreviewResponse.of(post, getPostImages(images), hashtags));
         });

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -15,6 +15,8 @@ spring:
 
   flyway:
     enabled: true # Flyway 마이그레이션을 활성화합니다.
+    cleanOnValidationError: true # 마이그레이션 중 오류가 발생하면 스키마를 삭제합니다.
+    cleanDisabled: false # 마이그레이션을 비활성화하면 스키마를 삭제하지 않습니다.
     baselineOnMigrate: false # 기존 스키마에 베이스라인을 설정하여 마이그레이션을 시작할 수 있게 합니다.
     validateOnMigrate: true # 마이그레이션 실행 전에 스키마가 예상대로 되어 있는지 검증합니다.
     locations: classpath:db/migration # 마이그레이션 파일의 위치를 지정합니다.
@@ -44,6 +46,9 @@ spring:
     show-sql: true
     properties:
       hibernate:
+        jdbc.batch_size: 50
+        order_inserts: true
+        order_updates: true
         "[format_sql]": true
     database-platform: org.hibernate.dialect.OracleDialect
 
@@ -97,6 +102,8 @@ cloud:
 logging:
   level:
     org:
+      hibernate:
+        orm.jdbc.bind: TRACE
       springframework:
         data:
           elasticsearch:

--- a/src/main/resources/db/migration/V5__update_sequence.sql
+++ b/src/main/resources/db/migration/V5__update_sequence.sql
@@ -1,0 +1,42 @@
+DROP SEQUENCE users_seq;
+DROP SEQUENCE post_seq;
+DROP SEQUENCE comments_seq;
+DROP SEQUENCE image_seq;
+DROP SEQUENCE likes_seq;
+DROP SEQUENCE hashtag_seq;
+DROP SEQUENCE post_hashtag_seq;
+
+CREATE SEQUENCE users_seq
+    START WITH 1
+    INCREMENT BY 1
+    NOCYCLE;
+
+CREATE SEQUENCE post_seq
+    START WITH 1
+    INCREMENT BY 1
+    NOCYCLE;
+
+CREATE SEQUENCE comments_seq
+    START WITH 1
+    INCREMENT BY 1
+    NOCYCLE;
+
+CREATE SEQUENCE image_seq
+    START WITH 1
+    INCREMENT BY 10
+    NOCYCLE;
+
+CREATE SEQUENCE likes_seq
+    START WITH 1
+    INCREMENT BY 1
+    NOCYCLE;
+
+CREATE SEQUENCE hashtag_seq
+    START WITH 1
+    INCREMENT BY 10
+    NOCYCLE;
+
+CREATE SEQUENCE post_hashtag_seq
+    START WITH 1
+    INCREMENT BY 10
+    NOCYCLE;


### PR DESCRIPTION
1. flyway sql파일에서 스키마 수정 시 DBeaver에서 더 이상 스키마 삭제 안해도 됩니다. 앱 실행 시 자동으로 flyway가 스키마 삭제하고 생성해 줍니다.
2. 게시글 검색 시 es로 쿼리하는 기능 수정 중.
3. 프론트엔드는 게시글 수정 기능 완료. 삭제 기능은 구현 중.
4. post쪽은 jpql 최적화 진행 중. (쿼리 문이 여러 개 생성되는 이슈)
5. 로그 출력 시 jpa 쿼리문에 무엇이 바인딩 되었는지 로그 출력하게 기능 추가.
6. 해쉬태그 중복 입력 방지하도록 로직 수정