### PR TITLE
feat: guest 로그인 기능 구현. 

### DIFF
--- a/src/main/java/com/fisa/dailytravel/global/config/CustomJwtAuthenticationFilter.java
+++ b/src/main/java/com/fisa/dailytravel/global/config/CustomJwtAuthenticationFilter.java
@@ -1,0 +1,42 @@
+package com.fisa.dailytravel.global.config;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.Map;
+
+@Component
+public class CustomJwtAuthenticationFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = request.getHeader("Authorization");
+
+        if (token == null) {
+            //create guset
+            Jwt guestJwt = new Jwt(
+                    "guest-token", // 토큰 값
+                    Instant.now(), // 발행 시간
+                    Instant.MAX, // 매우 먼 미래로 만료 시간 설정
+                    Map.of("alg", "none"), // 헤더
+                    Map.of("sub", "guest", "name", "Guest", "email", "test@test.com", "picture", "https://avatars.githubusercontent.com/u/124599?v=4") // 클레임
+            );
+
+            JwtAuthenticationToken guestAuthToken = new JwtAuthenticationToken(guestJwt, Collections.emptyList());
+            SecurityContextHolder.getContext().setAuthentication(guestAuthToken);
+        }
+
+        // 다음 필터로 요청 전달
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/fisa/dailytravel/global/config/SecurityConfig.java
+++ b/src/main/java/com/fisa/dailytravel/global/config/SecurityConfig.java
@@ -39,7 +39,8 @@ public class SecurityConfig {
                     oauth2.jwt(jwt -> {
                         jwt.jwtAuthenticationConverter(jwtAuthConverter);
                     });
-                });
+                }).addFilterBefore(new CustomJwtAuthenticationFilter(), org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter.class);
+
 
         return http.build();
     }

--- a/src/main/java/com/fisa/dailytravel/user/controller/UserController.java
+++ b/src/main/java/com/fisa/dailytravel/user/controller/UserController.java
@@ -25,10 +25,9 @@ public class UserController {
         userCreateRequest.setEmail(email);
         userCreateRequest.setUuid(principal.getName());
         userCreateRequest.setPicture(picture);
-        userService.signin(userCreateRequest);
+        UserCreateResponse userCreateResponse = userService.signin(userCreateRequest);
 
-        UserCreateResponse response = new UserCreateResponse("User created successfully");
-        return ResponseEntity.status(HttpStatus.CREATED).body(response);
+        return ResponseEntity.status(userCreateResponse.getStatus()).body(userCreateResponse);
     }
 
     @GetMapping("/v1/user")

--- a/src/main/java/com/fisa/dailytravel/user/dto/UserCreateResponse.java
+++ b/src/main/java/com/fisa/dailytravel/user/dto/UserCreateResponse.java
@@ -1,12 +1,14 @@
 package com.fisa.dailytravel.user.dto;
 
-import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @Setter
-@AllArgsConstructor
+@Builder
 public class UserCreateResponse {
+    private HttpStatus status;
     private String message;
 }

--- a/src/main/java/com/fisa/dailytravel/user/service/UserService.java
+++ b/src/main/java/com/fisa/dailytravel/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.fisa.dailytravel.user.service;
 
 import com.fisa.dailytravel.user.dto.UserCreateRequest;
+import com.fisa.dailytravel.user.dto.UserCreateResponse;
 import com.fisa.dailytravel.user.dto.UserGetResponse;
 import com.fisa.dailytravel.user.dto.UserUpdateRequest;
 import com.fisa.dailytravel.user.dto.UserUpdateResponse;
@@ -8,7 +9,7 @@ import com.fisa.dailytravel.user.dto.UserUpdateResponse;
 import java.io.IOException;
 
 public interface UserService {
-    void signin(UserCreateRequest userCreateRequest) throws Exception;
+    UserCreateResponse signin(UserCreateRequest userCreateRequest) throws Exception;
 
     UserGetResponse getUser(String uuid) throws Exception;
 

--- a/src/main/java/com/fisa/dailytravel/user/service/UserServiceImpl.java
+++ b/src/main/java/com/fisa/dailytravel/user/service/UserServiceImpl.java
@@ -7,6 +7,7 @@ import com.fisa.dailytravel.post.models.Image;
 import com.fisa.dailytravel.post.models.Post;
 import com.fisa.dailytravel.post.repository.PostRepository;
 import com.fisa.dailytravel.user.dto.UserCreateRequest;
+import com.fisa.dailytravel.user.dto.UserCreateResponse;
 import com.fisa.dailytravel.user.dto.UserGetResponse;
 import com.fisa.dailytravel.user.dto.UserUpdateRequest;
 import com.fisa.dailytravel.user.dto.UserUpdateResponse;
@@ -16,6 +17,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -35,7 +37,7 @@ public class UserServiceImpl implements UserService {
 
     @Transactional
     @Override
-    public void signin(UserCreateRequest userCreateRequest) throws Exception {
+    public UserCreateResponse signin(UserCreateRequest userCreateRequest) throws Exception {
         User user = userRepository.findByUuid(userCreateRequest.getUuid());
         Optional<User> userOptional = Optional.ofNullable(user);
 
@@ -48,9 +50,18 @@ public class UserServiceImpl implements UserService {
             user.setEmail(userCreateRequest.getEmail());
             user.setProfileImagePath(userCreateRequest.getPicture());
             user.setIsDeleted(false);
+            userRepository.save(user);
+            return UserCreateResponse.builder()
+                    .status(HttpStatus.CREATED)
+                    .message("User created successfully")
+                    .build();
         }
 
-        userRepository.save(user);
+        return UserCreateResponse.builder()
+                .status(HttpStatus.OK)
+                .message("User signed in successfully")
+                .build();
+
     }
 
     @Transactional

--- a/src/test/java/com/fisa/dailytravel/user/controller/UserControllerTest.java
+++ b/src/test/java/com/fisa/dailytravel/user/controller/UserControllerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -46,7 +47,10 @@ class UserControllerTest {
 
     @Test
     void testSignin() throws Exception {
-        UserCreateResponse userCreateResponse = new UserCreateResponse("User created successfully");
+        UserCreateResponse userCreateResponse =  UserCreateResponse.builder()
+                .status(HttpStatus.CREATED)
+                .message("User created successfully")
+                .build();
 
         mockMvc.perform(post("/v1/user")
                         .principal(jwtAuthenticationToken)


### PR DESCRIPTION
## guest 로그인 기능 구현
Postman 테스트 시 Bearer token 입력 안하고 테스트 가능하게 guest 로그인 기능 구현

uuid가 guest로 생성되는 것에 주의.

![image](https://github.com/user-attachments/assets/e2aa6b73-3fe7-4a31-a8e6-c86035cff2a8)

### 1. Token항목을 비워두고  hello 요청을 날려서 jwt값 확인.
![image](https://github.com/user-attachments/assets/44984341-2f80-4f9a-b933-7bc01ccbf5ef)

### 2. 유저 회원가입&로그인 api 호출
![image](https://github.com/user-attachments/assets/52e0ae79-ef48-469e-8873-d6a87a1a2e66)

### 3. 유저 피드 불러오기
![image](https://github.com/user-attachments/assets/ab54c542-8996-4d3c-88f2-dd0aaa4560c8)

